### PR TITLE
Make Roka CMake's 'interface' library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(roka CXX)
+
+add_library(roka INTERFACE)
+target_include_directories(roka INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+cmake_policy(SET CMP0076 NEW)
+target_sources(roka INTERFACE
+    include/roka/roka.hpp
+)
+target_compile_features(roka INTERFACE cxx_std_17)
+
+if(ROKA_BUILD_TESTS)
+    add_subdirectory(src_test)
+endif()

--- a/README.md
+++ b/README.md
@@ -146,5 +146,5 @@ _Remark:_ (1) shall not participate in overload resolution unless `UInt` is an i
 ## For developers
 
 Roka has a small test in `src_test` directory.
-The test can be built with `cmake` with `CMakeLists.txt` is that directory.
+The test can be built with `cmake -S . -B build -DROKA_BUILD_TESTS=1` in the root directory.
 No testing frameworks are employed.

--- a/src_test/CMakeLists.txt
+++ b/src_test/CMakeLists.txt
@@ -1,28 +1,29 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
-enable_language(CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-project(test_roka)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 enable_testing()
 
-set(ROKA_HEADERS
-    ../include/roka/roka.hpp
-)
+add_executable(test_roka)
+
+get_target_property(ROKA_HEADERS roka INTERFACE_SOURCES)
 
 set(TEST_ROKA_SOURCES
     test_roka.cpp
 )
 
-add_executable(test_roka
+target_sources(test_roka PRIVATE
     ${ROKA_HEADERS}
     ${TEST_ROKA_SOURCES}
 )
 
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 source_group("Roka Headers" FILES ${ROKA_HEADERS})
+
+target_compile_features(test_roka PRIVATE cxx_std_17)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(test_roka PRIVATE /MP /W4)
@@ -30,14 +31,23 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_definitions(test_roka PRIVATE
         $<$<NOT:$<CONFIG:Debug>>:NDEBUG>
     )
-    target_compile_options(test_roka PRIVATE -Wall -Wextra -pedantic-errors -Werror=pedantic)
     target_compile_options(test_roka PRIVATE
+        -Wall -Wextra -pedantic-errors -Werror=pedantic
+        $<$<CONFIG:Debug>:-O0 -g3>
+        $<$<CONFIG:RelWithDebInfo>:-O2 -g3>
+    )
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_definitions(test_roka PRIVATE
+        $<$<NOT:$<CONFIG:Debug>>:NDEBUG>
+    )
+    target_compile_options(test_roka PRIVATE
+        -Wall -Wextra -pedantic-errors -Werror=pedantic
         $<$<CONFIG:Debug>:-O0 -g3>
         $<$<CONFIG:RelWithDebInfo>:-O2 -g3>
     )
 endif()
 
-include_directories(../include)
+target_link_libraries(test_roka PRIVATE roka)
 
 add_test(
     NAME test_roka


### PR DESCRIPTION
Literally make Roka 'interface' library of CMake.

And make the test built with `-DROKA_BUILD_TESTS=1` argument to `cmake`.