### PR TITLE
Employ "option" of CMake for ROKA_BUILD_TESTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
+option(ROKA_BUILD_TESTS "Whether to build Roka's test" OFF)
+
 project(roka CXX)
 
 add_library(roka INTERFACE)

--- a/README.md
+++ b/README.md
@@ -146,5 +146,5 @@ _Remark:_ (1) shall not participate in overload resolution unless `UInt` is an i
 ## For developers
 
 Roka has a small test in `src_test` directory.
-The test can be built with `cmake -S . -B build -DROKA_BUILD_TESTS=1` in the root directory.
+The test can be built with `cmake -S . -B build -DROKA_BUILD_TESTS=ON` in the root directory.
 No testing frameworks are employed.


### PR DESCRIPTION
Make `ROKA_BUILD_TESTS` an option of CMake to achieve clarity.